### PR TITLE
chore: remove env

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,0 @@
-#VITE_APP_API_BASE='https://sudosos.test.gewis.nl/api/v1'
-VITE_APP_API_BASE='https://sudosos.gewis.nl/api/v1'
-VITE_LIVE_APP_API_BASE='https://sudosos.gewis.nl/api/v1'
-VITE_LIVE_IMAGE_BASE='https://sudosos.gewis.nl/static/'
-VITE_APP_IMAGE_BASE='https://sudosos.gewis.nl/static/'

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ coverage
 *.njsproj
 *.sln
 *.sw?
+
+.env


### PR DESCRIPTION
Removes the .env, to allow this repository to be pushed to docker using different variables than the production one. And make it harder to accidently buy something from the production database.